### PR TITLE
Add support `baseUrl` and `paths` from tsconfig.json or jsconfig.json

### DIFF
--- a/packages/chayns-toolkit/README.md
+++ b/packages/chayns-toolkit/README.md
@@ -37,6 +37,7 @@ experience when working with [React](https://reactjs.org).
     -   [HMR With `react-refresh` Support](#hmr-with-react-refresh-support)
     -   [Using React Devtools](#using-react-devtools)
     -   [ESLint Configuration](#eslint-configuration)
+    -   [Support for custom path aliases](#support-for-custom-path-aliases)
     -   [Single-File Builds](#single-file-builds)
     -   [Environment Variables](#environment-variables)
     -   [Analyzing Your Bundle](#analyzing-your-bundle)
@@ -125,6 +126,7 @@ We recommend to use our included [ESLint configuration](#eslint-configuration).
 -   [HMR With `react-refresh` Support](#hmr-with-react-refresh-support)
 -   [Using React Devtools](#using-react-devtools)
 -   [ESLint Configuration](#eslint-configuration)
+-   [Support for custom path aliases](#support-for-custom-path-aliases)
 -   [Single-File Builds](#single-file-builds)
 -   [Environment Variables](#environment-variables)
 -   [Analyzing Your Bundle](#analyzing-your-bundle)
@@ -276,6 +278,35 @@ The configuration can also be installed as a standalone package
 If you think a rule should be enabled, disabled or adjusted, please consider
 [opening an issue](https://github.com/TobitSoftware/chayns-toolkit/issues/new)
 to discuss the suggested change instead of changing your local configuration.
+
+### Support for custom path aliases
+
+`chayns-toolkit` supports the `paths` and `baseUrl` options from `tsconfig.json`
+or `jsconfig.json` to create more readable paths.
+
+You can set the `baseUrl` like so:
+
+```json
+// tsconfig.json or jsconfig.json for non-TypeScript projects
+{
+    "compilerOptions": {
+        "baseUrl": "./src"
+    }
+}
+```
+
+Then you can import files based on your `baseUrl`:
+
+```ts
+// Import `MyComponent` from `./src/components/MyComponent`
+import { MyComponent } from "components/MyComponent"
+```
+
+If you want to know more about
+[`baseUrl`](https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url)
+and
+[`paths`](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping)
+check the TypeScript docs.
 
 ### Single-File Builds
 

--- a/packages/chayns-toolkit/package.json
+++ b/packages/chayns-toolkit/package.json
@@ -64,6 +64,7 @@
 		"source-map-loader": "^2.0.1",
 		"style-loader": "^2.0.0",
 		"tcp-port-used": "^1.0.2",
+		"tsconfig-paths-webpack-plugin": "^3.3.0",
 		"url-loader": "^4.1.1",
 		"webpack": "^5.25.0",
 		"webpack-bundle-analyzer": "^4.4.0",

--- a/packages/chayns-toolkit/src/util/createWebpackConfig.ts
+++ b/packages/chayns-toolkit/src/util/createWebpackConfig.ts
@@ -9,7 +9,7 @@ import { paramCase } from "param-case"
 import semver from "semver"
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin"
 import type { PackageJson } from "type-fest"
-import { Configuration } from "webpack"
+import { Configuration, ResolveOptions } from "webpack"
 import { BundleAnalyzerPlugin } from "webpack-bundle-analyzer"
 import { setBrowserslistEnvironment } from "../features/environment/browserslist"
 import { isPackageInstalled } from "./isPackageInstalled"
@@ -155,14 +155,11 @@ export async function createWebpackConfig({
 		)
 		.digest("hex")
 
-	type ResolveConfiguration = Exclude<Configuration["resolve"], undefined>
-
-	const resolvePlugins: Array<
-		Exclude<ResolveConfiguration["plugins"], undefined>
-	> = []
+	const resolvePlugins: Exclude<ResolveOptions["plugins"], undefined> = []
 
 	if (project.hasFile("jsconfig.json")) {
 		resolvePlugins.push(
+			// @ts-expect-error: IDK why this type is broken...
 			new TsconfigPathsPlugin({
 				configFile: "jsconfig.json",
 				extensions: [".js", ".jsx"],
@@ -170,6 +167,7 @@ export async function createWebpackConfig({
 		)
 	} else if (project.hasFile("tsconfig.json")) {
 		resolvePlugins.push(
+			// @ts-expect-error: IDK why this type is broken...
 			new TsconfigPathsPlugin({
 				extensions: [".js", ".jsx", ".ts", ".tsx"],
 			})

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -21,7 +21,7 @@ module.exports = {
 	},
 	settings: {
 		"import/resolver": {
-			node: { extensions: [".js", ".jsx", ".ts", ".tsx"] },
+			typescript: { project: "@(jsconfig|tsconfig).json" },
 		},
 		"import/extensions": [".js", ".jsx", ".ts", ".tsx"],
 	},
@@ -34,6 +34,7 @@ module.exports = {
 				"plugin:@typescript-eslint/recommended",
 				"plugin:@typescript-eslint/recommended-requiring-type-checking",
 				"prettier",
+				"plugin:import/typescript",
 			],
 			rules: {
 				...sharedRules,

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -31,6 +31,7 @@
 		"eslint-config-airbnb": "^18.2.1",
 		"eslint-config-airbnb-typescript": "^12.3.1",
 		"eslint-config-prettier": "^8.1.0",
+		"eslint-import-resolver-typescript": "^2.4.0",
 		"eslint-plugin-import": "^2.22.1",
 		"eslint-plugin-jest": "^24.2.1",
 		"eslint-plugin-jsx-a11y": "^6.4.1",

--- a/packages/example-project/src/App.jsx
+++ b/packages/example-project/src/App.jsx
@@ -1,14 +1,14 @@
+import CorejsTest from "components/corejs-test/CorejsTest"
+import CssModules from "components/css-modules/CssModules"
+import EnvTest from "components/env-test/EnvTest"
+import FileLoaderTest from "components/file-loader-test/FileLoaderTest"
+import HmrTest from "components/hmr-test/HmrTest"
+import PipelineOperatorTest from "components/pipeline-operator-test/PipelineOperatorTest"
+import SvgTest from "components/svg-test/SvgTest"
+import TsTest from "components/ts-test/TsTest"
+import UrlLoaderTest from "components/url-loader-test/UrlLoaderTest"
 import React, { Suspense } from "react"
 import "./App.css"
-import CorejsTest from "./components/corejs-test/CorejsTest"
-import CssModules from "./components/css-modules/CssModules"
-import EnvTest from "./components/env-test/EnvTest"
-import FileLoaderTest from "./components/file-loader-test/FileLoaderTest"
-import HmrTest from "./components/hmr-test/HmrTest"
-import PipelineOperatorTest from "./components/pipeline-operator-test/PipelineOperatorTest"
-import SvgTest from "./components/svg-test/SvgTest"
-import TsTest from "./components/ts-test/TsTest"
-import UrlLoaderTest from "./components/url-loader-test/UrlLoaderTest"
 
 const LazyComponent = React.lazy(() =>
 	import("./components/code-splitting-test/CodeSplittingTest")

--- a/packages/example-project/tsconfig.json
+++ b/packages/example-project/tsconfig.json
@@ -10,6 +10,7 @@
 		"lib": ["DOM", "ESNext"],
 		"noEmit": true,
 		"skipLibCheck": true,
-		"strict": true
+		"strict": true,
+		"baseUrl": "src/"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5606,6 +5606,17 @@ eslint-import-resolver-node@^0.3.4:
     debug "^2.6.9"
     resolve "^1.13.1"
 
+eslint-import-resolver-typescript@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.4.0.tgz#ec1e7063ebe807f0362a7320543aaed6fe1100e1"
+  integrity sha512-useJKURidCcldRLCNKWemr1fFQL1SzB3G4a0li6lFGvlc5xGe1hY343bvG07cbpCzPuM/lK19FIJB3XGFSkplA==
+  dependencies:
+    debug "^4.1.1"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    resolve "^1.17.0"
+    tsconfig-paths "^3.9.0"
+
 eslint-module-utils@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz#579ebd094f56af7797d19c9866c9c9486629bfa6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3989,7 +3989,7 @@ chalk@^1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -5368,6 +5368,15 @@ end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+enhanced-resolve@^4.0.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz#2f3cfd84dbe3b487f18f2db2ef1e064a571ca5ec"
+  integrity sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    memory-fs "^0.5.0"
+    tapable "^1.0.0"
 
 enhanced-resolve@^5.7.0:
   version "5.7.0"
@@ -8723,6 +8732,14 @@ memory-fs@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
   integrity sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=
+  dependencies:
+    errno "^0.1.3"
+    readable-stream "^2.0.1"
+
+memory-fs@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.5.0.tgz#324c01288b88652966d161db77838720845a8e3c"
+  integrity sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
@@ -12462,6 +12479,11 @@ table@^6.0.4:
     slice-ansi "^4.0.0"
     string-width "^4.2.0"
 
+tapable@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
+  integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
+
 tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
@@ -12756,7 +12778,16 @@ trim-off-newlines@^1.0.0:
   dependencies:
     glob "^7.1.2"
 
-tsconfig-paths@^3.9.0:
+tsconfig-paths-webpack-plugin@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.3.0.tgz#a7461723c20623ca9148621a5ce36532682ad2ff"
+  integrity sha512-MpQeZpwPY4gYASCUjY4yt2Zj8yv86O8f++3Ai4o0yI0fUC6G1syvnL9VuY71PBgimRYDQU47f12BEmJq9wRaSw==
+  dependencies:
+    chalk "^2.3.0"
+    enhanced-resolve "^4.0.0"
+    tsconfig-paths "^3.4.0"
+
+tsconfig-paths@^3.4.0, tsconfig-paths@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
   integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==


### PR DESCRIPTION
This feature is pretty much the same as the equivalent Next.js feature: https://nextjs.org/docs/advanced-features/module-path-aliases