### PR TITLE
Disable `react/no-danger`

### DIFF
--- a/packages/eslint-config/rules/sharedRules.js
+++ b/packages/eslint-config/rules/sharedRules.js
@@ -26,6 +26,7 @@ const sharedRules = {
 			name: "chayns-components/lib",
 		},
 	],
+	"react/no-danger": "off",
 }
 
 module.exports = sharedRules


### PR DESCRIPTION
Closes #16 

The property is literally named `dangerouslySetInnerHtml`, I think one warning is enough. You don't have to disable ESLint for the line as well.

[`eslint-config-react-app`](https://github.com/facebook/create-react-app/blob/master/packages/eslint-config-react-app/index.js) also does not have it enabled.